### PR TITLE
gaia: fix python3.8 missing command, fix gaiafusion shebang

### DIFF
--- a/gaia.rb
+++ b/gaia.rb
@@ -6,10 +6,12 @@ class Gaia < Formula
   url "https://github.com/MTG/gaia/archive/v2.4.6.tar.gz"
   version "2.4.6"
   sha256 "9e7f57150d3bb9547477624b44103743841409226681bc4b3773dbddfd610b39"
+  revision 1
 
   head 'https://github.com/MTG/gaia.git'
 
   include Language::Python::Virtualenv
+  include Language::Python::Shebang
 
   depends_on "pkg-config"
   depends_on "python@3.8"
@@ -23,24 +25,34 @@ class Gaia < Formula
     sha256 "01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4"
   end
 
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+    sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+  end
+
   def install
     #venv = virtualenv_create(libexec, "python3")
     #venv.pip_install resource("PyYAML")
 
-    system Formula["python@3.8"].opt_bin/"python3", "waf", "configure", "--with-python-bindings",
+    system Formula["python@3.8"].opt_bin/"python3.8", "waf", "configure", "--with-python-bindings",
                                           "--prefix=#{prefix}"
-    system Formula["python@3.8"].opt_bin/"python3", "waf"
-    system Formula["python@3.8"].opt_bin/"python3", "waf", "install"
+    system Formula["python@3.8"].opt_bin/"python3.8", "waf"
+    system Formula["python@3.8"].opt_bin/"python3.8", "waf", "install"
 
     resource("PyYAML").stage do
-      system Formula["python@3.8"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
+      system Formula["python@3.8"].opt_bin/"python3.8", *Language::Python.setup_install_args(libexec)
     end
 
-    version = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3"
+    resource("six").stage do
+      system Formula["python@3.8"].opt_bin/"python3.8", *Language::Python.setup_install_args(libexec)
+    end
+
+    version = Language::Python.major_minor_version Formula["python@3.8"].opt_bin/"python3.8"
     site_packages = "lib/python#{version}/site-packages"
     pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
     (prefix/site_packages/"homebrew-gaia.pth").write pth_contents
 
+    rewrite_shebang detected_python_shebang, bin/"gaiafusion"
   end
 
   #test do


### PR DESCRIPTION
- Not sure when it changed, but it seems the `python@3.8` formula only has a (symlink) `bin/python3.8`, and no `python3`, which is part of the reason `gaia` installs from this tap may have been failing ~(possibly it's a difference between x86/arm? not sure)~ I think this is actually a homebrew convention - as of the past few minor versions - versioned python formula do NOT provide an unversioned `python` bin
- updated the shebang in the `gaiafusion` python script; it was using `/usr/bin/env python3`, which did not properly have `gaia2` installed
- install resource `six`, which `gaia2.fusion` depends on

I can't test on x86, but this change works for me on a M1 mac.