### PR TITLE
Fix: essentia on apple silicon

### DIFF
--- a/essentia.rb
+++ b/essentia.rb
@@ -20,7 +20,7 @@ class Essentia < Formula
   option "without-python", "Build without Python 3.9 support"
 
   depends_on "python@3.9" if build.with? "python"
-  depends_on "numpy" if build.with? "python"
+  depends_on "mtg/essentia/numpy@1.23.3" if build.with? "python"
 
   resource "six" do
     url "https://files.pythonhosted.org/packages/21/9f/b251f7f8a76dec1d6651be194dfba8fb8d7781d10ab3987190de8391d08e/six-1.14.0.tar.gz"
@@ -44,9 +44,9 @@ class Essentia < Formula
       build_flags += ["--with-tensorflow"]
     end
 
-    system Formula["python@3.9"].opt_bin/"python3", "waf", "configure", *build_flags
-    system Formula["python@3.9"].opt_bin/"python3", "waf"
-    system Formula["python@3.9"].opt_bin/"python3", "waf", "install"
+    system Formula["python@3.9"].opt_bin/"python3.9", "waf", "configure", *build_flags
+    system Formula["python@3.9"].opt_bin/"python3.9", "waf"
+    system Formula["python@3.9"].opt_bin/"python3.9", "waf", "install"
 
     python_flags = [
       "--mode=release",
@@ -58,15 +58,18 @@ class Essentia < Formula
     ENV['PKG_CONFIG_PATH'] = "#{prefix}/lib/pkgconfig:" + ENV['PKG_CONFIG_PATH']
 
     if build.with? "python"
-      system Formula["python@3.9"].opt_bin/"python3", "waf", "configure", *python_flags
-      system Formula["python@3.9"].opt_bin/"python3", "waf"
-      system Formula["python@3.9"].opt_bin/"python3", "waf", "install"
+      site_packages = Language::Python.site_packages(Formula["python@3.9"].opt_libexec/"bin/python")
+      ENV.prepend_create_path "PYTHONPATH", Formula["mtg/essentia/numpy@1.23.3"].opt_prefix/site_packages
+
+      system Formula["python@3.9"].opt_bin/"python3.9", "waf", "configure", *python_flags
+      system Formula["python@3.9"].opt_bin/"python3.9", "waf"
+      system Formula["python@3.9"].opt_bin/"python3.9", "waf", "install"
 
       resource("six").stage do
-        system Formula["python@3.9"].opt_bin/"python3", *Language::Python.setup_install_args(libexec)
+        system Formula["python@3.9"].opt_bin/"python3.9", *Language::Python.setup_install_args(libexec)
       end
 
-      version = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3"
+      version = Language::Python.major_minor_version Formula["python@3.9"].opt_bin/"python3.9"
       site_packages = "lib/python#{version}/site-packages"
       pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
       (prefix/site_packages/"homebrew-essentia.pth").write pth_contents
@@ -85,7 +88,7 @@ class Essentia < Formula
     EOS
 
     if build.with? "python"
-      system Formula["python@3.9"].opt_bin/"python3", "-c", "#{py_test}"
+      system Formula["python@3.9"].opt_bin/"python3.9", "-c", "#{py_test}"
     end
   end
 end

--- a/essentia.rb
+++ b/essentia.rb
@@ -2,6 +2,7 @@ class Essentia < Formula
   desc "Library for audio analysis and audio-based music information retrieval"
   homepage "http://essentia.upf.edu"
   head 'https://github.com/MTG/essentia.git'
+  revision 1
 
   include Language::Python::Virtualenv
 

--- a/libcython@0.29.30.rb
+++ b/libcython@0.29.30.rb
@@ -14,14 +14,14 @@ class LibcythonAT02930 < Formula
     Users are advised to use `pip` to install cython
   EOS
 
-  depends_on "python@3.10" => [:build, :test]
+  # depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.9" => [:build, :test]
 
   def pythons
     deps.map(&:to_formula)
         .select { |f| f.name.match?(/python@\d\.\d+/) }
         .map(&:opt_bin)
-        .map { |bin| bin/"python3" }
+        .map { |bin| bin/"python3.9" }
   end
 
   def install

--- a/libcython@0.29.30.rb
+++ b/libcython@0.29.30.rb
@@ -1,0 +1,52 @@
+class LibcythonAT02930 < Formula
+  desc "Compiler for writing C extensions for the Python language"
+  homepage "https://cython.org/"
+  url "https://files.pythonhosted.org/packages/d4/ad/7ce0cccd68824ac9623daf4e973c587aa7e2d23418cd028f8860c80651f5/Cython-0.29.30.tar.gz"
+  sha256 "2235b62da8fe6fa8b99422c8e583f2fb95e143867d337b5c75e4b9a1a865f9e3"
+  license "Apache-2.0"
+
+  livecheck do
+    formula "cython"
+  end
+
+  keg_only <<~EOS
+    this formula is mainly used internally by other formulae.
+    Users are advised to use `pip` to install cython
+  EOS
+
+  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.9" => [:build, :test]
+
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/python@\d\.\d+/) }
+        .map(&:opt_bin)
+        .map { |bin| bin/"python3" }
+  end
+
+  def install
+    pythons.each do |python|
+      ENV.prepend_create_path "PYTHONPATH", libexec/Language::Python.site_packages(python)
+      system python, *Language::Python.setup_install_args(libexec),
+             "--install-lib=#{libexec/Language::Python.site_packages(python)}"
+    end
+  end
+
+  test do
+    phrase = "You are using Homebrew"
+    (testpath/"package_manager.pyx").write "print '#{phrase}'"
+    (testpath/"setup.py").write <<~EOS
+      from distutils.core import setup
+      from Cython.Build import cythonize
+
+      setup(
+        ext_modules = cythonize("package_manager.pyx")
+      )
+    EOS
+    pythons.each do |python|
+      ENV.prepend_path "PYTHONPATH", libexec/Language::Python.site_packages(python)
+      system python, "setup.py", "build_ext", "--inplace"
+      assert_match phrase, shell_output("#{python} -c 'import package_manager'")
+    end
+  end
+end

--- a/numpy@1.23.3.rb
+++ b/numpy@1.23.3.rb
@@ -12,6 +12,8 @@ class NumpyAT1233 < Formula
   depends_on "python@3.9" => [:build, :test]
   depends_on "openblas"
 
+  conflicts_with "numpy", because: "both install f2py and other binaries"
+
   fails_with gcc: "5"
 
   def pythons
@@ -42,6 +44,26 @@ class NumpyAT1233 < Formula
       system python, "setup.py", "build", "--fcompiler=#{Formula["gcc"].opt_bin}/gfortran",
                                           "--parallel=#{ENV.make_jobs}"
       system python, *Language::Python.setup_install_args(prefix, python)
+    end
+  end
+
+  def caveats
+    on_macos do
+      <<-EOS
+        This formula technically conflicts with the current Homebrew
+        version of `numpy`, as they both provide binaries. However,
+        the only result is that this formula can't be fully linked.
+
+        Since essentia only requires numpy's python bindings, there are
+        a few solutions (you only need to do one of the following):
+
+          1. `brew uninstall numpy` (easiest, only if you have no formulae that depend on numpy)
+          2. `brew unlink numpy`, then install this formula
+          3. If you need to keep `numpy` linked after installing this, you must run the
+             following to use this version of numpy when calling python3.9:
+
+            export PYTHONPATH="#{opt_prefix/Language::Python.site_packages(Formula["python@3.9"].opt_libexec/"bin/python")}"
+      EOS
     end
   end
 

--- a/numpy@1.23.3.rb
+++ b/numpy@1.23.3.rb
@@ -7,8 +7,8 @@ class NumpyAT1233 < Formula
   head "https://github.com/numpy/numpy.git", branch: "main"
 
   depends_on "gcc" => :build # for gfortran
-  depends_on "libcython" => :build
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "mtg/essentia/libcython@0.29.30" => :build
+  # depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.9" => [:build, :test]
   depends_on "openblas"
 
@@ -37,7 +37,7 @@ class NumpyAT1233 < Formula
 
     pythons.each do |python|
       site_packages = Language::Python.site_packages(python)
-      ENV.prepend_path "PYTHONPATH", Formula["libcython"].opt_libexec/site_packages
+      ENV.prepend_path "PYTHONPATH", Formula["mtg/essentia/libcython@0.29.30"].opt_libexec/site_packages
 
       system python, "setup.py", "build", "--fcompiler=#{Formula["gcc"].opt_bin}/gfortran",
                                           "--parallel=#{ENV.make_jobs}"

--- a/numpy@1.23.3.rb
+++ b/numpy@1.23.3.rb
@@ -1,0 +1,58 @@
+class NumpyAT1233 < Formula
+  desc "Package for scientific computing with Python"
+  homepage "https://www.numpy.org/"
+  url "https://files.pythonhosted.org/packages/0a/88/f4f0c7a982efdf7bf22f283acf6009b29a9cc5835b684a49f8d3a4adb22f/numpy-1.23.3.tar.gz"
+  sha256 "51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd"
+  license "BSD-3-Clause"
+  head "https://github.com/numpy/numpy.git", branch: "main"
+
+  depends_on "gcc" => :build # for gfortran
+  depends_on "libcython" => :build
+  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.9" => [:build, :test]
+  depends_on "openblas"
+
+  fails_with gcc: "5"
+
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/^python@\d\.\d+$/) }
+        .sort_by(&:version) # so that `bin/f2py` and `bin/f2py3` use python3.10
+        .map { |f| f.opt_libexec/"bin/python" }
+  end
+
+  def install
+    openblas = Formula["openblas"]
+    ENV["ATLAS"] = "None" # avoid linking against Accelerate.framework
+    ENV["BLAS"] = ENV["LAPACK"] = openblas.opt_lib/shared_library("libopenblas")
+
+    config = <<~EOS
+      [openblas]
+      libraries = openblas
+      library_dirs = #{openblas.opt_lib}
+      include_dirs = #{openblas.opt_include}
+    EOS
+
+    Pathname("site.cfg").write config
+
+    pythons.each do |python|
+      site_packages = Language::Python.site_packages(python)
+      ENV.prepend_path "PYTHONPATH", Formula["libcython"].opt_libexec/site_packages
+
+      system python, "setup.py", "build", "--fcompiler=#{Formula["gcc"].opt_bin}/gfortran",
+                                          "--parallel=#{ENV.make_jobs}"
+      system python, *Language::Python.setup_install_args(prefix, python)
+    end
+  end
+
+  test do
+    pythons.each do |python|
+      system python, "-c", <<~EOS
+        import numpy as np
+        t = np.ones((3,3), int)
+        assert t.sum() == 9
+        assert np.dot(t, t).sum() == 27
+      EOS
+    end
+  end
+end


### PR DESCRIPTION
Fixes #30, fixes #32, fixes #33

The misconception in the linked issue description is that `depends_on "numpy"` should install numpy bindings, which `essentia` requires. However, homebrew's current `numpy` no longer supports `python3.9`, which is why the build was failing to find numpy. That is also why running `python3.9 -m pip install numpy` will allow `essentia` to build properly, although it is generally not recommended to install python modules to a homebrew python distribution manually.

Instead, I've done the following:
- `brew extract --version=0.29.30 libcython mtg/essentia`
    - get the last version of `libcython` (*from homebrew*) that uses python3.9
    - restrict it to `python3.9`
- `brew extract --version=1.23.3 numpy mtg/essentia`
    - get the last version of `numpy` (*from homebrew*) that uses python3.9
    - restrict it to `python3.9`, and use this tap's `libcython`
    - add an explanation for users that this and `homebrew-core/numpy` conflict
- update this formula to use an explicit python version, fixing that issue about symlinking `python3.9 -> python` manually

Note that the formulae i've extracted from `homebrew-core` are just the most recent versions that had `depends_on "python@3.9"`. Newer versions of `libcython` and `numpy` support 3.9 but I didn't want to extract the current version and have to backport it in case there were other changes. 

slight note: i think that `--with-gaia` bindings might be broken/not fully working, since that formula uses `python@3.8`. I can submit a pr later that will update that.